### PR TITLE
Remove go-bingo language server from language list

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,7 +48,6 @@ nav:
     - Fortran: page/lsp-fortran.md
     - GDScript: page/lsp-gdscript.md
     - Go (gopls): page/lsp-gopls.md
-    - Go (bingo): page/lsp-bingo.md
     - Grammarly: page/lsp-grammarly.md
     - Groovy: page/lsp-groovy.md
     - Hack: page/lsp-hack.md


### PR DESCRIPTION
The documentation for go-bingo was removed but it was still present in the language list https://emacs-lsp.github.io/lsp-mode/page/languages/. It is now removed.